### PR TITLE
Vertically align PhysiKon logo in navbar

### DIFF
--- a/_includes/navbar.html
+++ b/_includes/navbar.html
@@ -4,7 +4,7 @@
 
 
         <a class="navbar-brand js-scroll-trigger" href="/index.html">
-          <img class="mb-4" src="img/logos-physikon/logo-pfeil-gruen-inverse.svg" alt="" style="width: 100%; background-color: white">
+          <img src="img/logos-physikon/logo-pfeil-gruen-inverse.svg" alt="" style="width: 100%; background-color: white">
         </a>
 
         <!-- Navbar (mobile) -->


### PR DESCRIPTION
Gibt es einen Grund, dass das Logo in der Navigation nach oben versetzt ist?

Hiermit ist es vertikal zentriert.