### PR TITLE
add IAV and change Physiker to MINT-Leute

### DIFF
--- a/_data/unternehmen.json
+++ b/_data/unternehmen.json
@@ -27,7 +27,13 @@
     "logo": "/img/logos/dfine_dunkelblau.png",
     "url": "https://www.d-fine.com/"
   },
-
+  {
+    "name": "IAV",
+    "title": "Wir entwickeln was bewegt",
+    "caption": "IAV – Ihr Partner für Automotive Engineering. Als einer der global führenden Engineering-Partner entwickelt IAV die Mobilität der Zukunft.",
+    "logo": "/img/logos/iav.png",
+    "url": "https://www.iav.com"
+  },
   {
     "name": "EY-Parthenon",
     "title": "We take strategy personally",
@@ -42,6 +48,7 @@
     "logo": "/img/logos/grandcentrix_logo_288x68.jpg",
     "url": "https://grandcentrix.net/"
   },
+  
   {
     "name": "point8",
     "title": "Data Science as a Service",

--- a/_includes/exhibitors.html
+++ b/_includes/exhibitors.html
@@ -1,9 +1,9 @@
 <header class="masthead bg-primary text-white text-center">
   <div class="container">
-  <h2 class="h2-fontsize  py-5">Sie möchten Physiker/innen für Ihr Unternehmen gewinnen?</h2>
+  <h2 class="h2-fontsize  py-5">Sie suchen schlaue Köpfe und motivierte Absolventen oder Studierende aus dem MINT-Bereich?</h2>
   <p style="font-size: 2rem">
   Die PhysiKon 2020 bietet Ihnen die Gelegenheit, Ihr Unternehmen für Absolventen und
-  Absolventinnen der Physik attraktiv zu präsentieren.</p>
+  Absolventinnen aller MINT-Fakultäten der TU Dortmund attraktiv zu präsentieren.</p>
 </div>
 </header>
 


### PR DESCRIPTION
Ich hab die IAV hinzugefügt und "Sie möchten Physiker/innen für Ihr Unternehmen gewinnen?" durch
"Sie suchen schlaue Köpfe und motivierte Absolventen oder Studierende aus dem MINT-Bereich?" ersetzt