### PR TITLE
Fix hover color of Physikon logo

### DIFF
--- a/css/custom.css
+++ b/css/custom.css
@@ -65,6 +65,12 @@ body {
   background-color: var(--pep-gray) !important;
 }
 
+a.bg-secondary:hover, a.bg-secondary:focus,
+button.bg-secondary:hover,
+button.bg-secondary:focus {
+  background-color: var(--pep-gray) !important;
+}
+
 /* choose primary, secondary text-colors */
 .text-primary {
   color: var(--pep-yellow) !important;


### PR DESCRIPTION
The background color of the Physikon Logo changes when hovering which looks quite ugly. I hope I fixed it.

And btw, the pep-color there and the color of the physikon logo are not the same as it seams. But therefore probably the logo needs to be changed.

![image](https://user-images.githubusercontent.com/41512963/158364125-e46568fb-8f61-4dd0-ada0-f785b86b4d89.png)
